### PR TITLE
update docker-compose.imgproxy.yaml to remove hardcoded ports

### DIFF
--- a/docker-compose.imgproxy.yaml
+++ b/docker-compose.imgproxy.yaml
@@ -2,18 +2,22 @@
 services:
     imgproxy:
         container_name: ddev-${DDEV_SITENAME}-imgproxy
-        hostname: ${DDEV_SITENAME}-imgproxy
         image: darthsim/imgproxy:latest
+        restart: "no"
+        # These labels ensure this service is discoverable by ddev.
         labels:
             com.ddev.site-name: ${DDEV_SITENAME}
             com.ddev.approot: $DDEV_APPROOT
         networks: [default, ddev_default]
         environment:
+            VIRTUAL_HOST: $DDEV_HOSTNAME
+            HTTPS_EXPOSE: 8081:8080
+            HTTP_EXPOSE: 8080:8080
             IMGPROXY_BASE_URL: http://web:80
             IMGPROXY_ALLOW_ORIGIN: "*"
-        ports:
-            - "8081:8080"
         volumes:
+            - ".:/mnt/ddev_config"
+            - "ddev-global-cache:/mnt/ddev-global-cache"
             - "imgproxy-cache:/imgproxy/cache"
 
 volumes:


### PR DESCRIPTION
Thanks to Stanislav Zhuk wo figured this out:
https://github.com/barbieswimcrew/ddev-imgproxy/issues/1#issuecomment-2462034785